### PR TITLE
Allows running stand-alone (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "cargo-open"
 version = "0.3.0"
 dependencies = [
  "cargo 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -31,6 +31,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -67,10 +72,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "1.2.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ description = "A third-party cargo extension to allow you to open a dependent cr
 name = "cargo-open"
 
 [dependencies]
-clap = "*"
+clap = "~1.4"
 cargo = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate clap;
 extern crate cargo;
 
 use clap::{Arg, App, AppSettings, SubCommand};
-use cargo::core::SourceId;
+use cargo::core::{SourceId};
 use cargo::util::{hex, CargoResult};
 
 use std::env;
@@ -26,11 +26,25 @@ fn main() {
               .help("The name of the crate you would like to open")
               .required(true)
               .index(1)))
-        .settings(&[AppSettings::SubcommandRequired])
+        .arg(Arg::with_name("CRATE")
+              .help("The name of the crate you would like to open")
+              .required(true))
+        .setting(AppSettings::SubcommandsNegateReqs)
         .get_matches();
 
     // Ok to use unwrap here because clap will handle argument errors
-    let crate_name = matches.subcommand_matches("open").unwrap().value_of("CRATE").unwrap();
+    let crate_name = match matches.value_of("CRATE") {
+        Some(c) => {
+            if env::var_os("CARGO_HOME").is_none() {
+                // TODO: set CARGO_HOME env var
+            }
+            c
+        },
+        None => matches.subcommand_matches("open")
+                       .unwrap()
+                       .value_of("CRATE")
+                       .unwrap()
+    };
 
     let crate_dir = match cargo_dir(crate_name) {
         Ok(path) => path,


### PR DESCRIPTION
**DO NOT MERGE**

This small change allows running `cargo-open` standalone _as well as_ as a subcommand of `cargo`...well, _almost_. 

Running `cargo open <crate>` works as expected. Running `cargo-open <crate>` also works...but not quite as expected. The problem is `$CARGO_HOME` isn't set when `cargo` doesn't run. (Also note, `cargo-open` or `cargo open` without a crate still spits out the required error messages :wink:)

If you know of a way to cleanly set `$CARGO_HOME` (to include when users are using `multirust`) it should be as simple as setting that variable. I'm just not familiar enough with `cargo` (yet) to set it manually.

Overall this would make hacking on `cargo-open` a little easier/faster. So if it's something you'd like to pursue I'll keep looking for something that'll work :smile:
